### PR TITLE
Extension for getting all possible child digimon based on a supplied parent 'mon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                 <input class="btn btn-primary btn-block" type="submit" ng-click="searchResultingDigimon(resultingDigimon)" value="Search">
             </form>
 
-            <table id="content-table" ng-show="result.combinationsToGetDigimon.length > 0" class="table table-bordered table-hover">
+            <table id="content-table" ng-show="result.combinationsToGetDigimon.length > 0 || result.digivolution != null" class="table table-bordered table-hover">
                 <tr>
                     <th><a href="">Combinations</a></th>
                 </tr>

--- a/index.html
+++ b/index.html
@@ -21,14 +21,21 @@
                 <span style="margin-top: 20px; margin-bottom: 20px;" ng-show="elCalculator.result > 0">New EL: {{elCalculator.result}}</span>
             </form>
 
-            <form>
-                <h5 class="display-6">Combinations</h5>
-                <input class="form-control" type="text" placeholder="Digimon Name" ng-model='digimon.name'
-                    ng-keypress="checkForEnter($event)">
-                <input class="btn btn-primary btn-block" type="submit" ng-click="searchDigimon(digimon)" value="Search">
+            <form style="margin-top: 20px; margin-bottom: 20px;">
+                <h5 class="display-6">Combinations (to get Digimon)</h5>
+                <input class="form-control" type="text" placeholder="Desired Digimon Name" ng-model='targetDigimon.name'
+                       ng-keypress="checkForTargetDigimonEnter($event)">
+                <input class="btn btn-primary btn-block" type="submit" ng-click="searchTargetDigimon(targetDigimon)" value="Search">
             </form>
 
-            <table id="content-table" ng-show="result.combinations.length > 0" class="table table-bordered table-hover">
+            <form>
+                <h5 class="display-6">Combinations (available from Digimon)</h5>
+                <input class="form-control" type="text" placeholder="Parent Digimon Name" ng-model='resultingDigimon.name'
+                       ng-keypress="checkForResultingDigimonEnter($event)">
+                <input class="btn btn-primary btn-block" type="submit" ng-click="searchResultingDigimon(resultingDigimon)" value="Search">
+            </form>
+
+            <table id="content-table" ng-show="result.combinationsToGetDigimon.length > 0" class="table table-bordered table-hover">
                 <tr>
                     <th><a href="">Combinations</a></th>
                 </tr>
@@ -36,17 +43,42 @@
                     <tr ng-repeat="result in result.digivolution">
                         <td>{{result}}</td>
                     </tr>
-                    <tr ng-repeat="result in result.combinations">
+                    <tr ng-repeat="result in result.combinationsToGetDigimon">
                         <td>{{result.first.name}} - {{result.second.name}}</td>
                     </tr>
                 </tbody>
             </table>
 
-            <p>Thanks to Marshall Morris and Dogeci for the guide source to this: <a
-                    href="https://gamefaqs.gamespot.com/ps/437339-digimon-world-2/faqs/61067">link</a></p>
+            <table id="content-table" ng-show="result.combinationsFromDigimon.results.length > 0" class="table table-bordered table-hover">
+                <tr>
+                    <th><a href="">Combinations</a></th>
+                </tr>
+                <tbody>
+                <tr ng-repeat="availableCombinations in result.combinationsFromDigimon.results">
 
-            <p>The source for this site can be found in <a
-                href="https://github.com/Klauswk/dw2-dna-combinations">github</a></p>
+                    <td>
+                        <div>
+                            <h5>{{availableCombinations.childDigimon.name}}</h5>
+                            <div class="d-flex flex-wrap justify-content-center">
+                                <div ng-repeat="secondParent in availableCombinations.secondParents" class="btn-primary btn m-2 w-25  ">
+                                    {{result.combinationsFromDigimon.firstParent}} + {{secondParent.name}}
+                                </div>
+                            </div>
+                        </div>
+
+                    </td>
+
+                </tr>
+                </tbody>
+            </table>
+
+            <p>
+                Thanks to Marshall Morris and Dogeci for the guide source to this: <a href="https://gamefaqs.gamespot.com/ps/437339-digimon-world-2/faqs/61067">link</a>
+            </p>
+
+            <p>
+                The source for this site can be found in <a href="https://github.com/Klauswk/dw2-dna-combinations">github</a>
+            </p>
         </div>
     </div>
     <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.8.0/angular.min.js"></script>

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -325,7 +325,7 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
         console.log("Code:", code);
         dnaTable[codeAsColumnNum].forEach((row, rowNumb) => {
             var rowLetter = String.fromCharCode(65 + rowNumb);
-            console.log(rowLetter, row);
+
             //The dnaTable has an extra row for some reason, may look into it later.
             if (row !== "") {
                 var entryInCombinations = dnaCombinations.find(k => k.childDigiID === row);
@@ -362,7 +362,7 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
 
             if (digimonByName.stage === 2) {
                 var result = searchInTable(uuDnaTable, digimonByName.uc);
-                console.log("Result: ", result);
+
                 var combinations = findUUCombination(result);
 
                 if (digimonByName.name === "Yanmamon") {

--- a/js/controllers/mainController.js
+++ b/js/controllers/mainController.js
@@ -74,6 +74,28 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
         return 0;
     }
 
+    var sortByChildName = function (a, b) {
+        if (a.childDigimon.name < b.childDigimon.name) {
+            return -1;
+        }
+        if (a.childDigimon.name > b.childDigimon.name) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+    var sortBySecondParentName = function (a, b) {
+        if (a.name < b.name) {
+            return -1;
+        }
+        if (a.name > b.name) {
+            return 1;
+        }
+
+        return 0;
+    }
+
     var ccDnaTable = loadCCDnaTable();
 
     var uuDnaTable = loadUUDnaTable();
@@ -176,6 +198,113 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
         return arrayCombination;
     }
 
+    var findDigimonDataForRookieChildAndChampionParents = function(childDigimonAndSecondParentSet) {
+        var combinationsFromDigimon = [];
+        childDigimonAndSecondParentSet.forEach(otherParentAndChild => {
+            var resultingDigimon = null;
+            var secondParentsAsDigimonObjects = [];
+            rookieArray.forEach(possibleResultingDigimon => {
+                if (otherParentAndChild.childDigiID === possibleResultingDigimon.cc) {
+                    resultingDigimon = possibleResultingDigimon;
+                }
+            });
+            otherParentAndChild.secondParents.forEach(secondParent => {
+                championArray.forEach(possibleSecondParent => {
+                    if (secondParent === possibleSecondParent.cc) {
+                        secondParentsAsDigimonObjects.push(possibleSecondParent);
+                    }
+                });
+            });
+
+            secondParentsAsDigimonObjects.sort(sortBySecondParentName);
+
+            combinationsFromDigimon.push({
+                childDigimon: resultingDigimon,
+                secondParents: secondParentsAsDigimonObjects
+            });
+
+
+        });
+
+        return combinationsFromDigimon;
+    }
+
+    var findDigimonDataForChampionChildAndUltimateParents = function (childDigimonAndSecondParentSet) {
+        var combinationsFromDigimon = [];
+        childDigimonAndSecondParentSet.forEach(otherParentAndChild => {
+            var resultingDigimon = null;
+            var secondParentsAsDigimonObjects = [];
+            if (otherParentAndChild.childDigiID.charAt(0) === "M") {
+                if (otherParentAndChild.childDigiID === "MA") {
+                    resultingDigimon = search({ name: "Vademon" });
+                }
+            } else {
+                championArray.forEach(possibleResultingDigimon => {
+                    if (otherParentAndChild.childDigiID === possibleResultingDigimon.uc) {
+                        resultingDigimon = possibleResultingDigimon;
+                    }
+                });
+            }
+            
+            otherParentAndChild.secondParents.forEach(secondParent => {
+                ultimateArray.forEach(possibleSecondParent => {
+                    if (secondParent === possibleSecondParent.uc) {
+                        secondParentsAsDigimonObjects.push(possibleSecondParent);
+                    }
+                });
+            });
+
+            secondParentsAsDigimonObjects.sort(sortBySecondParentName);
+
+            combinationsFromDigimon.push({
+                childDigimon: resultingDigimon,
+                secondParents: secondParentsAsDigimonObjects
+            });
+
+
+        });
+
+        return combinationsFromDigimon;
+    }
+
+    var findDigimonDataForUltimateChildAndMegaParents = function (childDigimonAndSecondParentSet) {
+        var combinationsFromDigimon = [];
+        childDigimonAndSecondParentSet.forEach(otherParentAndChild => {
+            var resultingDigimon = null;
+            var secondParentsAsDigimonObjects = [];
+            if (otherParentAndChild.childDigiID.charAt(0) === "M") {
+                if (otherParentAndChild.childDigiID === "MB") {
+                    resultingDigimon = search({ name: "SandYanmamon" });
+                }
+                if (otherParentAndChild.childDigiID === "MC") {
+                    resultingDigimon = search({ name: "Yanmamon" });
+                }
+            } else {
+                ultimateArray.forEach(possibleResultingDigimon => {
+                    if (otherParentAndChild.childDigiID === possibleResultingDigimon.mc) {
+                        resultingDigimon = possibleResultingDigimon;
+                    }
+                });
+            }
+            otherParentAndChild.secondParents.forEach(secondParent => {
+                megaArray.forEach(possibleSecondParent => {
+                    if (secondParent === possibleSecondParent.mc) {
+                        secondParentsAsDigimonObjects.push(possibleSecondParent);
+                    }
+                });
+            });
+
+            secondParentsAsDigimonObjects.sort(sortBySecondParentName);
+
+            combinationsFromDigimon.push({
+                childDigimon: resultingDigimon,
+                secondParents: secondParentsAsDigimonObjects
+            });
+        });
+
+        return combinationsFromDigimon;
+    }
+
     var searchInTable = function (dnaTable, code) {
         var indexes = [];
 
@@ -190,7 +319,30 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
         return indexes;
     }
 
-    var searchDigimon = (digimon) => {
+    var searchForDNAPartners = function (dnaTable, code) {
+        var dnaCombinations = [];
+        var codeAsColumnNum = code.charCodeAt(0) - 65;
+        console.log("Code:", code);
+        dnaTable[codeAsColumnNum].forEach((row, rowNumb) => {
+            var rowLetter = String.fromCharCode(65 + rowNumb);
+            console.log(rowLetter, row);
+            //The dnaTable has an extra row for some reason, may look into it later.
+            if (row !== "") {
+                var entryInCombinations = dnaCombinations.find(k => k.childDigiID === row);
+                if (entryInCombinations === undefined || entryInCombinations === null) {
+                    dnaCombinations.push({ childDigiID: row, secondParents: [rowLetter] });
+                } else {
+                    entryInCombinations.secondParents.push(rowLetter);
+                }
+            }
+
+        });
+
+        return dnaCombinations;
+    }
+
+
+    var searchTargetDigimon = (digimon) => {
         $scope.result = {};
 
         var digimonByName = search(digimon);
@@ -205,12 +357,12 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
 
                 combinations.sort(sortByName);
 
-                $scope.result.combinations = combinations;
+                $scope.result.combinationsToGetDigimon = combinations;
             }
 
             if (digimonByName.stage === 2) {
                 var result = searchInTable(uuDnaTable, digimonByName.uc);
-
+                console.log("Result: ", result);
                 var combinations = findUUCombination(result);
 
                 if (digimonByName.name === "Yanmamon") {
@@ -227,7 +379,7 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
 
                 combinations.sort(sortByName);
 
-                $scope.result.combinations = combinations;
+                $scope.result.combinationsToGetDigimon = combinations;
                 $scope.result.digivolution = digimonByName.digivolution;
             }
 
@@ -245,20 +397,71 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
 
                 combinations.sort(sortByName);
 
-                $scope.result.combinations = combinations;
+                $scope.result.combinationsToGetDigimon = combinations;
                 $scope.result.digivolution = digimonByName.digivolution;
             }
 
             if (digimonByName.stage === 4) {
                 $scope.result.digivolution = digimonByName.digivolution;
-                $scope.result.combinations = [{ first: { name: "Can't combine mega to get other mega" }, second: { name: "" } }];
+                $scope.result.combinationsToGetDigimon = [{ first: { name: "Can't combine mega to get other mega" }, second: { name: "" } }];
             }
         }
     };
 
-    var checkForEnter = (event) => {
+    var searchResultingDigimon = (digimon) => {
+        $scope.result = {};
+
+        var digimonByName = search(digimon);
+        console.log("DigimonByName: ", digimonByName);
+        
+        var dnaTable;
+        var firstParentID;
+        var combinationsFromDigimon = null;
+
+        if (digimonByName.stage === 1) {
+            //Is Rookie, can't DNA Digivolve
+        }
+        else if (digimonByName.stage === 2) {
+            dnaTable = ccDnaTable;
+            firstParentID = digimonByName.cc;
+            var resultStage2 = searchForDNAPartners(dnaTable, firstParentID);
+
+            combinationsFromDigimon =
+                findDigimonDataForRookieChildAndChampionParents(resultStage2);
+        }
+        else if (digimonByName.stage === 3) {
+            dnaTable = uuDnaTable;
+            firstParentID = digimonByName.uc;
+            var resultStage3 = searchForDNAPartners(dnaTable, firstParentID);
+
+            combinationsFromDigimon =
+                findDigimonDataForChampionChildAndUltimateParents(resultStage3);
+        }
+        else if (digimonByName.stage === 4) {
+            dnaTable = mmDnaTable;
+            firstParentID = digimonByName.mc;
+            var resultStage4 = searchForDNAPartners(dnaTable, firstParentID);
+
+            combinationsFromDigimon =
+                findDigimonDataForUltimateChildAndMegaParents(resultStage4);
+
+        }
+
+        if (combinationsFromDigimon !== null && combinationsFromDigimon !== undefined) {
+            combinationsFromDigimon.sort(sortByChildName);
+            $scope.result.combinationsFromDigimon = { firstParent : digimon.name, results: combinationsFromDigimon};
+        }
+    }
+
+    var checkForTargetDigimonEnter = (event) => {
         if( event.keyCode == 13 || event.which == 13 ) {
-            searchDigimon($scope.digimon);
+            searchTargetDigimon($scope.targetDigimon);
+        }
+    }
+
+    var checkForResultingDigimonEnter = (event) => {
+        if (event.keyCode == 13 || event.which == 13) {
+            searchResultingDigimon($scope.resultingDigimon);
         }
     }
 
@@ -278,9 +481,13 @@ angular.module("dw2DnaCombinations").controller("mainController", function ($sco
 
     $scope.result = {};
 
-    $scope.searchDigimon = searchDigimon;
+    $scope.searchTargetDigimon = searchTargetDigimon;
 
-    $scope.checkForEnter = checkForEnter;
+    $scope.searchResultingDigimon = searchResultingDigimon;
+
+    $scope.checkForTargetDigimonEnter = checkForTargetDigimonEnter;
+
+    $scope.checkForResultingDigimonEnter = checkForResultingDigimonEnter;
 
     $scope.calculateEl = calculateEl;
 


### PR DESCRIPTION
Pretty straightforward really, I tried to keep somewhat close to the original code style but renamed where things would be hard to follow now that there's two similar paths through the DNA tables.
I also added a small tweak to the original behaviour, where if a 'mon didn't have any valid DNA combinations it wouldn't return the digivolution options either.
If you're happy with this it'd be nice to have the updates on the heroku app too, no point in making a separate one for more features.